### PR TITLE
Handle GitHub Events

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -4,12 +4,13 @@
 import sys
 import json
 import buildbot
+import logging
 
 from buildbot.plugins import util, steps, worker, schedulers
 from buildbot.www.hooks.github import GitHubEventHandler
 from buildbot.steps.worker import CompositeStepMixin
 from twisted.internet import defer
-
+from twisted.python import log
 
 ###############################################################################
 # Global Functions
@@ -271,24 +272,125 @@ for i in range(1, BUILDBOT_NUMBER_MASTER_WORKERS + 1):
 # We don't really use the change_source config, instead we use the 
 # change_hook_dialects in the www config. This listens for request sent from 
 # GitHub or GitLab.
+#
+# GitHub API types:
+# https://developer.github.com/v3/activity/events/types/
 ###############################################################################
 class GitHubChangeHandler(GitHubEventHandler):
 
+    def handle_push(self, payload, event):
+        changes = []
+        
+        repository_url       = payload["repository"]["html_url"]  # https://github.com/winepak/org.winepak.Example
+        repository_git_url   = payload["repository"]["git_url"]   # git://github.com/winepak/org.winepak.Example
+        repository_ssh_url   = payload["repository"]["ssh_url"]   # git://github.com/winepak/org.winepak.Example
+        repository_clone_url = payload["repository"]["clone_url"] # https://github.com/winepak/org.winepak.Example.git
+        repository_name      = payload["repository"]["name"]      # org.winepak.Example
+        repository_fullname  = payload["repository"]["full_name"] # winepak/org.winepak.Example
+        project              = repository_name.replace("/", "-")  # winepak-org.winepak.Example
+        
+        # Push Specific
+        ref                  = payload["ref"]
+        branch               = ref[len("refs/heads/"):]
+        
+        log.msg("Processing GitHub push")
+        
+        if not ref.startswith("refs/heads/"):
+            log.msg("Ignoring request, refname `{}' is not a branch".format(ref))
+            return None
+        
+        if payload.get("deleted"):
+            log.msg("Ignoring request, branch `{}' was deleted".format(branch))
+            return None
+        
+        change = {
+            "repository": repository_url,
+            "branch": branch,
+            "project": project,
+            "author": payload["sender"]["login"],
+            "comments": "GitHub Push Request",
+            "category": "pull-request"
+        }
+        
+        changes.append(change)
+
+        return changes, "git"
+
+    def handle_pull_request(self, payload, event):
+        changes = []
+        
+        repository_url       = payload["repository"]["html_url"]  # https://github.com/winepak/org.winepak.Example
+        repository_git_url   = payload["repository"]["git_url"]   # git://github.com/winepak/org.winepak.Example
+        repository_ssh_url   = payload["repository"]["ssh_url"]   # git://github.com/winepak/org.winepak.Example
+        repository_clone_url = payload["repository"]["clone_url"] # https://github.com/winepak/org.winepak.Example.git
+        repository_name      = payload["repository"]["name"]      # org.winepak.Example
+        repository_fullname  = payload["repository"]["full_name"] # winepak/org.winepak.Example
+        project              = repository_name.replace("/", "-")  # winepak-org.winepak.Example
+        
+        # Pull Request Specific
+        issue_number         = payload["number"]
+        branch               = "refs/pull/{}/head".format(issue_number)
+
+        log.msg("Processing GitHub pull request #{}".format(issue_number))
+        
+        # Only track the following actioins
+        # We capture "push" with self.handle_push() and we only care about the first create
+        action = payload.get('action')
+        if action not in ('opened', 'reopened', 'synchronize'):
+            log.msg("Ignoring request, PR #{} `{}' not an action".format(issue_number, action))
+            return None
+        
+        # Pull Request Specific
+        author_association = payload["pull_request"]["author_association"]
+        
+        if author_association not in ["COLLABORATOR", "CONTRIBUTOR", "MEMBER", "OWNER"]:
+            log.msg("Ignoring request, user with association `{}' is not a trusted member".format(author_association))
+            return None
+        
+        change = {
+            "repository": repository_url,
+            "branch": branch,
+            "project": project,
+            "author": payload["sender"]["login"],
+            "comments": "GitHub Pull Request #{} test build\n".format(issue_number),
+            "category": "pull-request"
+        }
+        
+        changes.append(change)
+
+        return changes, "git"
+    
     def handle_issue_comment(self, payload, event):
-        body = payload["comment"]["body"]
-        assoc = payload["comment"]["author_association"]
-        issue_nr = payload["issue"]["number"]
-        issue_url = payload["comment"]["issue_url"]
-        sender = payload['sender']['login']
-        is_pull_request = 'pull_request' in payload['issue']
+        changes = []
+        
+        repository_url       = payload["repository"]["html_url"]  # https://github.com/winepak/org.winepak.Example
+        repository_git_url   = payload["repository"]["git_url"]   # git://github.com/winepak/org.winepak.Example
+        repository_ssh_url   = payload["repository"]["ssh_url"]   # git://github.com/winepak/org.winepak.Example
+        repository_clone_url = payload["repository"]["clone_url"] # https://github.com/winepak/org.winepak.Example.git
+        repository_name      = payload["repository"]["name"]      # org.winepak.Example
+        repository_fullname  = payload["repository"]["full_name"] # winepak/org.winepak.Example
+        project              = repository_name.replace("/", "-")  # winepak-org.winepak.Example
+        
+        # Comment Specific
+        body                 = payload["comment"]["body"]
+        issue_number         = payload["issue"]["number"]
+        issue_url            = payload["comment"]["issue_url"]
+        branch               = "refs/pull/{}/head".format(issue_number)
 
-        if not is_pull_request:
-            log.msg("Ignoring comment in non-pull-request")
-            return [], 'git'
-
+        log.msg("Processing GitHub comment #{}".format(issue_number))
+        
+        if not "pull_request" in payload["issue"]:
+            log.msg("Ignoring request, non-pull comment")
+            return None
+        
+        if payload.get("deleted"):
+            log.msg("Ignoring request, comment was deleted".format(branch))
+            return None
+        
+        # Comment Specific
         offset = body.find("bot, build");
         if offset == -1:
-            return [], 'git'
+            return None
 
         build_id = None
         rest = body[offset+len("bot, build"):]
@@ -298,38 +400,37 @@ class GitHubChangeHandler(GitHubEventHandler):
             if len(words) > 0:
                 build_id = words[0]
 
-        log.msg("Detected build test request in %s PR %d (id %s)" % (payload['repository']['html_url'], issue_nr, build_id))
-
-        if not assoc in ["COLLABORATOR", "CONTRIBUTOR", "MEMBER", "OWNER"]:
-            log.msg("WARNING: Ignoring build test request due to lack of perms")
-            return [], 'git'
-
-        project = payload['repository']['full_name'].replace("/", "-")
+        log.msg("Detected build test request in %s PR %d (id %s)" % (repository_url, issue_number, build_id))
         
-        if build_id:
-            project = 'forced-build-id-%s' % build_id
-            
+        author_association = payload["comment"]["author_association"]
+        
+        if author_association not in ["COLLABORATOR", "CONTRIBUTOR", "MEMBER", "OWNER"]:
+            log.msg("Ignoring request, user with association `{}' is not a trusted member".format(author_association))
+            return None
+        
         change = {
-            'branch': 'refs/pull/{}/head'.format(issue_nr),
-            'repository': payload['repository']['html_url'],
-            'project': project,
-            'category': 'bot-build',
-            'author': payload['sender']['login'],
-            'comments': u'GitHub Pull Request #%d test build\n' % (issue_nr)
+            "repository": repository_url,
+            "branch": branch,
+            "project": project,
+            "author": payload["sender"]["login"],
+            "comments": "GitHub Pull Request #{} test build\n".format(issue_number),
+            "category": "bot-build"
         }
+        
+        changes.append(change)
 
-        return [change], 'git'
+        return changes, "git"
 
 if GITHUB_CHANGE_SECRET is not None:
-    c['www']['change_hook_dialects']['github'] = {
-        'class': GitHubChangeHandler,
-        'secret': GITHUB_CHANGE_SECRET,
-        'strict': True
+    c["www"]["change_hook_dialects"]["github"] = {
+        "class": GitHubChangeHandler,
+        "secret": GITHUB_CHANGE_SECRET,
+        "strict": True
     }
 
 if GITLAB_CHANGE_SECRET is not None:
-    c['www']['change_hook_dialects']['gitlab'] = {
-        'secret': GITLAB_CHANGE_SECRET
+    c["www"]["change_hook_dialects"]["gitlab"] = {
+        "secret": GITLAB_CHANGE_SECRET
     }
 
 ###############################################################################
@@ -474,7 +575,8 @@ inherited_properties = [
     "repo_branch",
     "repo_build_config",
     "repo_build_subject",
-    "repo_build_arches"
+    "repo_build_arches",
+    "repo_build_issue_url"
 ]
 
 ###############################################################################


### PR DESCRIPTION
This expands and makes the GitHubEventHandler work. The following will trigger
a build:

- Opening a new pull request
- Reopening a pull request
- Synchronize a pull request
- Commenting "bot, build <application id>"
- Pushing changes to the repo

Only events from:

- COLLABORATOR
- CONTRIBUTOR
- MEMBER
- OWNER

Will trigger an events.